### PR TITLE
Add tests for Day2 and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,11 @@ Since I've got a bit of time, kind of wanted to get back into programming for a 
 
 ### Day 1
 - Python
+
+## Running Tests
+
+Install `pytest` and run the test suite from the repository root:
+
+```bash
+pytest
+```

--- a/tests/test_day2.py
+++ b/tests/test_day2.py
@@ -1,0 +1,37 @@
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import pytest
+from Day2.day2 import valid_row, updated_valid_row, part_a, part_b
+
+sample_rows = [
+    [1, 2, 3],      # valid increasing
+    [5, 3, 1],      # valid decreasing
+    [1, 5, 2],      # becomes valid after removing one element
+    [1, 5, 1],      # cannot be made valid
+]
+
+
+def test_valid_row():
+    assert valid_row([1, 2, 3])
+    assert valid_row([5, 3, 1])
+    assert not valid_row([1, 5, 2])
+    assert not valid_row([1, 5, 1])
+
+
+def test_updated_valid_row():
+    # Already valid rows remain valid
+    assert updated_valid_row([1, 2, 3])
+    # Removal of one element can make the row valid
+    assert updated_valid_row([1, 5, 2])
+    # This row cannot be made valid even after removing one element
+    assert not updated_valid_row([1, 5, 1])
+
+
+def test_part_a():
+    assert part_a(sample_rows) == 2
+
+
+def test_part_b(capsys):
+    result = part_b(sample_rows)
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "True"
+    assert result == 3


### PR DESCRIPTION
## Summary
- add unit tests covering `valid_row`, `updated_valid_row`, `part_a` and `part_b`
- make Day2 a package so tests can import modules
- document how to run the pytest suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c607f6fb8832eb3825eb24c578f46